### PR TITLE
🐛 Hotfix: 즐겨찾기 버튼 클릭 버그 수정

### DIFF
--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -251,23 +251,12 @@ function ToolCard({
     );
   };
 
-  const card = (
-    <GlassCard className="relative p-6 group">
+  const cardContent = (
+    <>
       {tool.status === 'comingSoon' && (
         <div className="absolute top-4 right-4 px-2 py-1 backdrop-blur-md bg-white/10 dark:bg-white/10 border border-gray-300 dark:border-white/20 text-gray-700 dark:text-gray-300 text-xs rounded">
           {comingSoonLabel}
         </div>
-      )}
-
-      {showFavorite && tool.status === 'available' && (
-        <button
-          onClick={handleFavoriteClick}
-          className="absolute top-4 right-4 text-2xl hover:scale-125 transition-transform duration-200"
-          aria-label={isFav ? '즐겨찾기 해제' : '즐겨찾기 추가'}
-          title={isFav ? '즐겨찾기 해제' : '즐겨찾기 추가'}
-        >
-          {isFav ? '⭐' : '☆'}
-        </button>
       )}
 
       <div className="text-4xl mb-4 group-hover:scale-110 transition-transform duration-300">{tool.icon}</div>
@@ -277,12 +266,32 @@ function ToolCard({
       </h3>
 
       <p className="text-gray-600 dark:text-gray-400 text-sm">{highlightText(tool.description, searchQuery)}</p>
-    </GlassCard>
+    </>
   );
 
   if (tool.status === 'available') {
-    return <Link href={`/tools/${tool.id}`}>{card}</Link>;
+    return (
+      <GlassCard className="relative p-6 group">
+        {showFavorite && (
+          <button
+            onClick={handleFavoriteClick}
+            className="absolute top-4 right-4 z-10 text-2xl hover:scale-125 transition-transform duration-200"
+            aria-label={isFav ? '즐겨찾기 해제' : '즐겨찾기 추가'}
+            title={isFav ? '즐겨찾기 해제' : '즐겨찾기 추가'}
+          >
+            {isFav ? '⭐' : '☆'}
+          </button>
+        )}
+        <Link href={`/tools/${tool.id}`} className="block">
+          {cardContent}
+        </Link>
+      </GlassCard>
+    );
   }
 
-  return card;
+  return (
+    <GlassCard className="relative p-6 group">
+      {cardContent}
+    </GlassCard>
+  );
 }


### PR DESCRIPTION
## 🐛 버그 설명
즐겨찾기 버튼(⭐/☆)을 클릭하면 즐겨찾기가 토글되어야 하는데, 대신 도구 페이지로 이동하는 버그가 발생했습니다.

## 🔍 원인 분석
`Link` 컴포넌트 안에 `button`이 중첩되어 있어, 버튼 클릭 이벤트가 상위 Link로 전파되는 **이벤트 버블링** 문제였습니다.

```tsx
// 문제가 있던 구조
<Link href="/tools/base64">
  <GlassCard>
    <button onClick={handleFavoriteClick}>⭐</button>
    {/* 카드 내용 */}
  </GlassCard>
</Link>
```

`e.preventDefault()`와 `e.stopPropagation()`을 사용했지만, Link 안에 button이 있는 구조에서는 제대로 작동하지 않았습니다.

## ✅ 해결 방법
카드 구조를 변경하여 버튼과 Link를 분리했습니다:

```tsx
// 수정된 구조
<GlassCard>
  <button onClick={handleFavoriteClick} className="z-10">⭐</button>
  <Link href="/tools/base64" className="block">
    {/* 카드 내용 */}
  </Link>
</GlassCard>
```

### 주요 변경사항
1. **버튼을 Link 외부로 이동**: 이벤트 전파 문제 해결
2. **z-index 설정**: 버튼을 상위 레이어로 배치 (`z-10`)
3. **Link를 block으로**: 카드 영역 전체를 클릭 가능하게 유지

## 🧪 테스트 결과
- ✅ 빌드 성공 (`npm run build`)
- ✅ 모든 단위 테스트 통과 (49 tests)
- ✅ ESLint 통과
- ✅ 수동 테스트: 즐겨찾기 버튼이 정상 작동

## 📊 영향 범위
- 모든 도구 카드의 즐겨찾기 기능
- 최근 사용/즐겨찾기 섹션 포함

## 🎯 우선순위
🔴 **High** - 핵심 기능 버그 수정 (Hotfix)

Fixes #56